### PR TITLE
Add id's in the Accessible Component Modules

### DIFF
--- a/AccDC Technical Style Guide/AccDC Technical Style Guide.htm
+++ b/AccDC Technical Style Guide/AccDC Technical Style Guide.htm
@@ -419,7 +419,7 @@ z-index: -1000;
                 </div>
                 <div class="Modules">
                     <div class="panel">
-                        <h3 class="control"><button id="tgl-2-1">Accordions</button></h3>
+                        <h3 class="control" id="accordions"><button id="tgl-2-1">Accordions</button></h3>
                         <div class="content hdn">
                             <p> Accordions are a fairly simple control type that are easy to make accessible.</p>
                             <p> Though similar in both concept and execution to Tab Controls, they are not the same.</p>
@@ -653,7 +653,7 @@ dc.close();
 					
 					
                     <div class="panel">
-                        <h3 class="control"><button id="tgl-2-2">ARIA Tabs</button></h3>
+                        <h3 class="control" id="aria-tabs"><button id="tgl-2-2">ARIA Tabs</button></h3>
                         <div class="content hdn">
                             <p> Tabs are a fairly simple control type that are easy to make accessible.</p>
                             <p> Though similar in both concept and execution to Accordions, they are not the same.</p>
@@ -921,7 +921,7 @@ dc.close();
 					
 					
                     <div class="panel">
-                        <h3 class="control"><button id="tgl-2-22">ARIA Comboboxes</button></h3>
+                        <h3 class="control" id="aria-comboboxes"><button id="tgl-2-22">ARIA Comboboxes</button></h3>
                         <div class="content hdn">
                             <p> ARIA Comboboxes are used to trigger dynamic lists of related options, such as with auto-suggest filters and custom dropdowns.</p>
                             <p> <strong>Expected behaviors:</strong></p>
@@ -1169,7 +1169,7 @@ myCombobox.dc
 					
 					
                     <div class="panel">
-                        <h3 class="control"><button id="tgl-2-21">ARIA Data Grids</button></h3>
+                        <h3 class="control" id="aria-data-grids"><button id="tgl-2-21">ARIA Data Grids</button></h3>
                         <div class="content hdn">
                             <p> An ARIA Data Grid is one of the most complicated of ARIA Widget types to make accessible, since it involves many different types of user interaction.</p>
                             <p> Expected behaviors: The entire grid should have only one tab stop, one cell should be focusable at a time, the arrow keys should move focus between cells, 
@@ -1663,7 +1663,7 @@ var myContainer = grid.container;
 					
 					
                     <div class="panel">
-                        <h3 class="control"><button id="tgl-2-3">ARIA Date Pickers</button></h3>
+                        <h3 class="control" id="aria-date-pickers"><button id="tgl-2-3">ARIA Date Pickers</button></h3>
                         <div class="content hdn">
                             <p> The ARIA Date Picker is a complex control type with a simple implementation.</p>
                             <p> <strong>Expected behaviors:</strong> The associated INPUT field should not include readonly, an external triggering element should activate the 
@@ -1945,7 +1945,7 @@ var year = dc.range.current.year; // '2012'
                     </div>
 					
                     <div class="panel">
-                        <h3 class="control"><button id="tgl-2-4">ARIA Listboxes</button></h3>
+                        <h3 class="control" id="aria-listboxes"><button id="tgl-2-4">ARIA Listboxes</button></h3>
                         <div class="content hdn">
                             <p> The ARIA Listbox is a simple concept, turned into a powerful component.</p>
                             <p> Expected behaviors: ARIA Listboxes should only receive one tab stop, the Up/Down/Home/End keys should move 
@@ -2129,7 +2129,7 @@ myListbox.activate.apply(listOptionDOM-Node); // Programmatically activate the '
 					
 					
                     <div class="panel">
-                        <h3 class="control"><button id="tgl-2-5">ARIA Menus</button></h3>
+                        <h3 class="control" id="aria-menus"><button id="tgl-2-5">ARIA Menus</button></h3>
                         <div class="content hdn">
                             <p> An ARIA Menu is a simple control type that can easily be made accessible.</p>
                             <p> <strong>Expected behaviors:</strong> A keyboard accessible mechanism opens the menu, the arrow keys are used to browse 
@@ -2584,7 +2584,7 @@ $A.trigger(originalTriggeringElement, 'closepopupmenu');
                     </div>
 										
                     <div class="panel">
-                        <h3 class="control"><button id="tgl-2-6">ARIA Radio Buttons</button></h3>
+                        <h3 class="control" id="aria-radio-buttons"><button id="tgl-2-6">ARIA Radio Buttons</button></h3>
                         <div class="content hdn">
                             <p> ARIA Radio buttons provide a means for rendering standard links as a radio button group.</p>
                             <p><strong> Expected behaviors:</strong> Only one radio button should receive focus in the tab order, regardless whether one or no 
@@ -2720,7 +2720,7 @@ myRadiogroup.set(arrayIndex); // Sets the radio option at the specified array in
                     </div>
 					
                     <div class="panel">
-                        <h3 class="control"><button id="tgl-2-7">ARIA Sliders</button></h3>
+                        <h3 class="control" id="aria-sliders"><button id="tgl-2-7">ARIA Sliders</button></h3>
                         <div class="content hdn">
                             <p> ARIA Sliders are used to present adjustable values for users, and can easily be made accessible.</p>
                             <p> Expected behaviors: The slider should have only one tab stop in the tab order, the arrow keys should move the slider in 
@@ -2894,7 +2894,7 @@ dc.set.apply(dc);
                     </div>
 					
                     <div class="panel">
-                        <h3 class="control"><button id="tgl-2-8">ARIA Toggles and Checkboxes</button></h3>
+                        <h3 class="control" id="aria-toggles-and-checkboxes"><button id="tgl-2-8">ARIA Toggles and Checkboxes</button></h3>
                         <div class="content hdn">
                             <p> The Toggle Control is a multipurpose control type, that covers checkboxes, toggle buttons, and even simulated links and buttons.</p>
                             <p> <strong>Expected behaviors:</strong> The general behavior of a Toggle control is to receive keyboard focus in the tab order regardless 
@@ -3088,7 +3088,7 @@ myToggle.set(Boolean); // Set the Toggle with the specified state (true or false
 					
 					
                     <div class="panel">
-                        <h3 class="control"><button id="tgl-2-9">ARIA Trees</button></h3>
+                        <h3 class="control" id="aria-trees"><button id="tgl-2-9">ARIA Trees</button></h3>
                         <div class="content hdn">
                             <p> An ARIA Tree is a complex control type that requires a lot of synchronizing to make accessible.</p>
                             <p> The reasons why: If the right ARIA attributes are not applied to the correct DOM nodes that receive keyboard focus, 
@@ -3283,7 +3283,7 @@ dc.top.close();
 					
 					
                     <div class="panel">
-                        <h3 class="control"><button id="tgl-2-10">Banners</button></h3>
+                        <h3 class="control" id="banners"><button id="tgl-2-10">Banners</button></h3>
                         <div class="content hdn">
                             <p> A Banner is a simple control type, which can easily be made accessible.</p>
                             <p> <strong>Expected behaviors:</strong> Ensure that the content of the banner appears at the top of the page, ensure that the beginning 
@@ -3438,7 +3438,7 @@ dc.close();
 					
 					
                     <div class="panel">
-                        <h3 class="control"><button id="tgl-2-11">Carousels, Slideshows, and Wizards</button></h3>
+                        <h3 class="control" id="carousels-slideshows-and-wizards"><button id="tgl-2-11">Carousels, Slideshows, and Wizards</button></h3>
                         <div class="content hdn">
                             <p> A Carousel is a complex control type that is easy to make accessible.</p>
                             <p> <strong>Expected behaviors:</strong> The beginning and ending boundaries should be conveyed to screen reader users, content 
@@ -3828,7 +3828,7 @@ var isStopped = dc.isStopped();
 					
 					
                     <div class="panel">
-                        <h3 class="control"><button id="tgl-2-12">Drag and Drop</button></h3>
+                        <h3 class="control" id="drag-and-drop"><button id="tgl-2-12">Drag and Drop</button></h3>
                         <div class="content hdn">
                             <p> Drag and Drop isn't called for much as part of a general feature set, but it's good to know how to make this 
 							functionality accessible for both screen reader and keyboard only users.</p>
@@ -4048,7 +4048,7 @@ dragClassName: 'ddLink'
                     </div>
 					
                     <div class="panel">
-                        <h3 class="control">
+                        <h3 class="control" id="footnotes">
                             <button id="tgl-2-13">Footnotes</button>
                         </h3>
                         <div class="content hdn">
@@ -4172,7 +4172,7 @@ backText: 'Back to Footnote'
 					
 					
                     <div class="panel">
-                        <h3 class="control">
+                        <h3 class="control" id="inline-form-field-validation">
                             <button id="tgl-2-14">Inline Form Field Validation</button>
                         </h3>
                         <div class="content hdn">
@@ -4396,7 +4396,7 @@ posAnchor: DOM-Node
 					
 					
                     <div class="panel">
-                        <h3 class="control">
+                        <h3 class="control" id="modals">
                             <button id="tgl-2-15">Modals</button>
                         </h3>
                         <div class="content hdn">
@@ -4626,7 +4626,7 @@ NVDA2013 announces as "Menu Button SubMenu"
 					
 					
                     <div class="panel">
-                        <h3 class="control">
+                        <h3 class="control" id="popups">
                             <button id="tgl-2-16">Popups</button>
                         </h3>
                         <div class="content hdn">
@@ -4848,7 +4848,7 @@ NVDA2013 announces as "Menu Button SubMenu"
 					
 					
                     <div class="panel">
-                        <h3 class="control">
+                        <h3 class="control" id="progress-bars">
                             <button id="tgl-2-17">Progress Bars</button>
                         </h3>
                         <div class="content hdn">
@@ -4975,7 +4975,7 @@ myProgressBar.close();
 					
 					
                     <div class="panel">
-                        <h3 class="control">
+                        <h3 class="control" id="scrollable-divs">
                             <button id="tgl-2-18">Scrollable Divs</button>
                         </h3>
                         <div class="content hdn">
@@ -5080,7 +5080,7 @@ NVDA2013 announces as "Menu Button SubMenu"
 					
 					
                     <div class="panel">
-                        <h3 class="control">
+                        <h3 class="control" id="tooltips">
                             <button id="tgl-2-19">Tooltips</button>
                         </h3>
                         <div class="content hdn">
@@ -5272,7 +5272,7 @@ NVDA2013 announces as "Menu Button SubMenu"
 					
 					
                     <div class="panel">
-                        <h3 class="control">
+                        <h3 class="control" id="web-chat">
                             <button id="tgl-2-20">Web Chat</button>
                         </h3>
                         <div class="content hdn">


### PR DESCRIPTION
... so that URLs which point to specific component modules can be created and shared, e.g.:

http://whatsock.com/tsg/#aria-menus

I guess there ought to also be internal page links on the page which point to each of these sections too, but this is a starting point.

Thoughts?
