### PR TITLE
Improve visual highlighting of the currently active tab.

### DIFF
--- a/AccDC Technical Style Guide/Coding Arena/ARIA and Non-ARIA Tabs/ARIA Tabs (Internal Content)/css/customize.css
+++ b/AccDC Technical Style Guide/Coding Arena/ARIA and Non-ARIA Tabs/ARIA Tabs (Internal Content)/css/customize.css
@@ -29,7 +29,8 @@ a[role=tab]:hover, a[role=tab]:focus {
 
 a[role=tab].active, a[role=tab].active:link, a[role=tab].active:visited {
 	color: #FFF;
-	background-color: #2E3135;
+	background-color: #E2A037;
+	text-decoration: underline;
 }
 
 #tabInsertId {


### PR DESCRIPTION
The existing visual highlighting of the currently active tab is not clear enough. Improve the contrast by using the same color that is used in the ARIA Date Picker widget for the currently selected date, and add an underline so that it is visible even without color.