### PR TITLE
Update to `runBefore()`'s date presetting

### DIFF
--- a/AccDC Technical Style Guide/2 Accessible Component Modules/calendar_generator.js
+++ b/AccDC Technical Style Guide/2 Accessible Component Modules/calendar_generator.js
@@ -835,8 +835,12 @@ Part of AccDC, a Cross-Browser JavaScript accessibility API, distributed under t
           },
           runBefore: function(dc) {
             // Mod:12/2019
-            if (!dc.rerendering && targ.value) {
-              dc.presetDate(dc, new Date(targ.value));
+            if (!dc.rerendering) {
+              var dateToPreset = dc.date || (targ.value ? new Date(targ.value) : null);
+
+              if (dateToPreset) {
+                dc.presetDate(dc, dateToPreset);
+              }
             }
 
             // Run custom specified function?


### PR DESCRIPTION
Hi Again,

I have a small update to fix a possible bug I'm experiencing. I'd like to run it by you first because it's possible I'm creating the bug by doing something goofy on my end. I noticed this when upgrading from version 1.x.

---

**Repro steps:**
1. Use a datepicker to select any date. For example, Feb 24, 2020.
2. Re-open the datepicker to select a new date.

**Expected Outcome:**
Feb 24, 2020 is preselected

**Actual Outcome:**
Feb 23, 2020 is preselected

---

In my setup, after a date has been selected, I update the associated input value to `YYYY-MM-DD` (`2020-02-24` in this example). In the affected lines of code, `targ.value = "2020-02-24"`. My UTC offset is -6 hours (CST, Chicago). When my browser parses that via `new Date("2020-01-24")`, the result is actually Feb 23, 2020 because of the negative offset.

It seemed to me that in general it would be a bit safer or precise to refer to the stored date object (if present) instead of re-parsing the input text, but again, I'm not sure if this only fixes my issue and/or if there is anything else that I am overlooking.

If you're not feeling good about this change being merged in, please feel free to decline the PR! All good!

Thanks and lease let me know your thoughts when you have some time.